### PR TITLE
Make pycnite compatible with Python 3.8-3.9 and run tests in 3.8-3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Type-Check
+      if: ${{ matrix.python-version != '3.11' }}
+      run: |
+        pip install pytype
+        pytype pycnite/ -j auto
+
+    - name: Run Tests
+      run: python -m unittest

--- a/pycnite/linetable.py
+++ b/pycnite/linetable.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 from . import types
 
 
-@dataclasses.dataclass(kw_only=True)
+@dataclasses.dataclass
 class Entry:
     """Position information for an opcode."""
 

--- a/pycnite/pyc.py
+++ b/pycnite/pyc.py
@@ -16,7 +16,7 @@
 
 import io
 
-from typing import IO
+from typing import IO, Union
 
 from . import magic
 from . import marshal
@@ -43,7 +43,7 @@ def load(fi: IO[bytes]):
     return marshal.loads(fi.read(), python_version)
 
 
-def loads(data: bytes | str):
+def loads(data: Union[bytes, str]):
     """Parse pyc data from a string.
 
     Args:

--- a/pycnite/types.py
+++ b/pycnite/types.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple, Union
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CodeTypeBase:
     """Pure python types.CodeType with python version added."""
 
@@ -40,7 +40,7 @@ class CodeTypeBase:
         return f"<code: {self.co_name}>"
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CodeType38(CodeTypeBase):
     """CodeType for python 3.8 - 3.10."""
 
@@ -51,7 +51,7 @@ class CodeType38(CodeTypeBase):
     co_cellvars: Tuple[str, ...]
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CodeType311(CodeTypeBase):
     """CodeType for python 3.11+."""
 
@@ -62,7 +62,7 @@ class CodeType311(CodeTypeBase):
     co_exceptiontable: bytes
 
 
-@dataclass(kw_only=True)
+@dataclass
 class Opcode:
     """Opcode with names and line numbers."""
 


### PR DESCRIPTION
* Removes kw_only option from dataclasses.
* Uses typing.Union instead of `|` syntax.
* Adds workflow to type-check and run tests in 3.8-3.11.

Fixes https://github.com/google/pycnite/issues/5.